### PR TITLE
Added explicit file support for CSV, PDF, XML

### DIFF
--- a/mailbox_org_api/Invoice.py
+++ b/mailbox_org_api/Invoice.py
@@ -5,6 +5,9 @@ class Invoice:
         self._status = None
         self._date = None
         self._token = None
+        self._csv = None
+        self._pdf = None
+        self._xml = None
 
     @property
     def account(self):
@@ -45,6 +48,30 @@ class Invoice:
     @token.setter
     def token(self, token: str):
         self._token = token
+
+    @property
+    def csv(self):
+        return self._csv
+
+    @csv.setter
+    def csv(self, csv: str):
+        self._csv = csv
+
+    @property
+    def pdf(self):
+        return self._pdf
+
+    @pdf.setter
+    def pdf(self, pdf: str):
+        self._pdf = pdf
+
+    @property
+    def xml(self):
+        return self._xml
+
+    @xml.setter
+    def xml(self, xml: str):
+        self._xml = xml
 
     def __str__(self) -> str:
         print_string = ''


### PR DESCRIPTION
Added support for one CSV, PDF and XML file per Invoice object.

It's not the best, most dynamic or most pythonic way, but there are only these three options and each one can be either empty or exactly one file. And additional functions for update, remove etc. are not needed.